### PR TITLE
Update caddy to install the v2 binary

### DIFF
--- a/caddy/local/plugin.sh
+++ b/caddy/local/plugin.sh
@@ -10,7 +10,13 @@ _caddy_internal() {
 }
 
 caddy_install() {
-	_caddy_internal "${FUNCNAME[0]}"
+	local tag="${1:-"v2.4.6"}"
+	local asset="${2:-"caddy_2.4.6_linux_amd64.tar.gz"}"
+
+	belt_remote_exec <<-SCRIPT
+		source "./toolbox/caddy/plugin.sh"
+		caddy_install "$tag" "$asset"
+	SCRIPT
 }
 
 caddy_start() {

--- a/caddy/remote/caddy.service
+++ b/caddy/remote/caddy.service
@@ -1,21 +1,17 @@
 [Unit]
 Description=Caddy
-After=network-online.target
-Wants=network-online.target systemd-networkd-wait-online.service
+After=network.target
 
 [Service]
 Restart=on-abnormal
 
 ; User and group the process will run as.
-User=www-data
-Group=www-data
+User=caddy
+Group=caddy
 
-; Letsencrypt-issued certificates will be written to this directory.
-Environment=CADDYPATH=/etc/ssl/caddy
-
-; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
-ExecReload=/bin/kill -USR1 $MAINPID
+; Specify the start command with a path to the main Caddyfile
+ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
 
 ; Use graceful shutdown with a reasonable timeout.
 KillMode=mixed
@@ -31,14 +27,11 @@ LimitNPROC=512
 ; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp=true
 
-; Hide /home /root /run/user to protect SSH keys.
-ProtectHome=true
-
 ; Make /usr /boot /etc read-only.
 ProtectSystem=full
 
-; Allow Caddy to write certs to /etc/ssl/caddy.
-ReadWriteDirectories=/etc/ssl/caddy
+; Grant capabilities that the process normally wouldn't have started with.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/caddy/remote/plugin.sh
+++ b/caddy/remote/plugin.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-export CADDY_BINARY="/usr/local/bin/caddy"
+export CADDY_BINARY="/usr/bin/caddy"
 export CADDY_CONFIG_DIR="/etc/caddy"
-export CADDY_SSL_DIR="/etc/ssl/caddy"
 export CADDY_SERVICE_FILE="/etc/systemd/system/caddy.service"
 export CADDY_SERVICE="caddy.service"
 
@@ -13,32 +12,39 @@ _caddy_abort() {
 }
 
 caddy_install() {
+	local tag="$1"
+	local asset="$2"
+	local url="https://github.com/caddyserver/caddy/releases/download/$tag/$asset"
+
 	if [[ -x "$(command -v caddy)" ]]; then
 		return 0
 	fi
 
-	(curl -s https://getcaddy.com | bash -s personal &>/dev/null) || _caddy_abort "install failed"
+	curl -Ls "$url" -o "/root/caddy.tar.gz" || _caddy_abort "curl failed"
 
-	chown root:root "$CADDY_BINARY"
+	mkdir -p "/root/caddy" || _caddy_abort "mkdir failed"
+	tar -zxf "/root/caddy.tar.gz" -C "/root/caddy" &>/dev/null || _caddy_abort "tar failed"
+	mv "/root/caddy/caddy" "$CADDY_BINARY"
+	rm -rf "/root/caddy" "/root/caddy.tar.gz"
+
+	groupadd --system caddy || _caddy_abort "groupadd failed"
+	useradd --system --gid caddy --create-home --home-dir /var/lib/caddy --shell /usr/sbin/nologin caddy || _caddy_abort "useradd failed"
+
+	chown caddy:caddy "$CADDY_BINARY"
 	chmod 755 "$CADDY_BINARY"
-
-	setcap 'cap_net_bind_service=+eip' "$CADDY_BINARY"
+	setcap 'cap_net_bind_service=+eip' "$CADDY_BINARY" || _caddy_abort "setcap failed"
 
 	mkdir -p "$CADDY_CONFIG_DIR/vhosts"
-	chown -R root:www-data "$CADDY_CONFIG_DIR"
-
-	mkdir -p "$CADDY_SSL_DIR"
-	chown -R www-data:root "$CADDY_SSL_DIR"
-	chmod 770 "$CADDY_SSL_DIR"
+	chown -R caddy:caddy "$CADDY_CONFIG_DIR"
 
 	cp "./toolbox/caddy/Caddyfile" "$CADDY_CONFIG_DIR/Caddyfile"
+	chown caddy:caddy "$CADDY_CONFIG_DIR/Caddyfile"
 
 	cp "./toolbox/caddy/caddy.service" "$CADDY_SERVICE_FILE"
 	chown root:root "$CADDY_SERVICE_FILE"
 	chmod 744 "$CADDY_SERVICE_FILE"
 
 	systemctl daemon-reload &>/dev/null || _caddy_abort "systemd reload failed"
-
 	systemctl enable "$CADDY_SERVICE" &>/dev/null || _caddy_abort "systemd enable failed"
 }
 


### PR DESCRIPTION
Downloads the latest (2.4.6) binary and uses `caddy` user/group to spin up the systemd service. 

Script borrowed from @martinrue's fork of the toolbox.